### PR TITLE
added feature to reduce figure and font quality

### DIFF
--- a/pdf2pdf.sh
+++ b/pdf2pdf.sh
@@ -23,6 +23,9 @@ do
 
 		# important, update time-stamp
 		touch $file
+		
+		# convert vector to raster and downscale to 75dpi (requires imagemagick)
+		convert -density 75 $file -quality 75 output.pdf
 
 		echo -e 'Conversion completed.\n'
 


### PR DESCRIPTION
It's important that all beautifully vectorized figures get reprocessed as low-res rasters. Also helps to unify naming conventions by converting file names to "output.pdf". 

Requires imagemagick, which can be installed by googling "install imagemagick <your OS>" and copy/pasting into terminal until something works. 

Super excited that my very first pull request is on this important project. 

Example output:

<img width="708" alt="screen shot 2018-02-17 at 9 49 19 am" src="https://user-images.githubusercontent.com/6476455/36343961-2a0c3fba-13c8-11e8-9b6a-34e055bc0a77.png">
<img width="724" alt="screen shot 2018-02-17 at 9 49 26 am" src="https://user-images.githubusercontent.com/6476455/36343962-2b78bf4a-13c8-11e8-83c1-ecb6fc0f212b.png">
